### PR TITLE
Update to latest beta using new performant types

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
         version: 24.0.5
       drizzle-kit:
         specifier: beta
-        version: 1.0.0-beta.1-f654053
+        version: 1.0.0-beta.1-f92627f
       drizzle-orm:
         specifier: beta
-        version: 1.0.0-beta.1-f654053(patch_hash=2d16276aaca83f4527accdf318385573a33f6c65a277314da3ec99dab205a053)(@libsql/client@0.15.9)
+        version: 1.0.0-beta.1-f92627f(patch_hash=2d16276aaca83f4527accdf318385573a33f6c65a277314da3ec99dab205a053)(@libsql/client@0.15.9)
       drizzle-plus:
         specifier: 'link:'
         version: 'link:'
@@ -960,12 +960,12 @@ packages:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
 
-  drizzle-kit@1.0.0-beta.1-f654053:
-    resolution: {integrity: sha512-MW1C/F8YySmm5uP1R2nlK52k+D2Xsj1V8HcJva/7Osokzh45rK6ZKXWaRTTIp7A75n6/KPyLzh50OuPX1lSrPw==}
+  drizzle-kit@1.0.0-beta.1-f92627f:
+    resolution: {integrity: sha512-56Fe9rJs/cy9SQsZzNWhJpDQ+47zx+pUh+coTmRng3aPjAneKL/drgBVc4H1W80+hBKLTj4suO3F8LS9ppQVQw==}
     hasBin: true
 
-  drizzle-orm@1.0.0-beta.1-f654053:
-    resolution: {integrity: sha512-CUhTzIVArN5SPjBu4m/8/4TagtMlRg4GU27oH2/vT+S7h8ran83oqsLoSSOlD9roLTejvADwy6gftCp9tNiHeQ==}
+  drizzle-orm@1.0.0-beta.1-f92627f:
+    resolution: {integrity: sha512-/3vjhufSgRJsj5GBqAWBI0EugKMdjdfK9xLLIjw65sk21ius6CHNJ8r3f0/kkAVxhM6mrfYqipVKt9UYF1DwKg==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -988,8 +988,6 @@ packages:
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
-      knex: '*'
-      kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
@@ -1038,10 +1036,6 @@ packages:
       expo-sqlite:
         optional: true
       gel:
-        optional: true
-      knex:
-        optional: true
-      kysely:
         optional: true
       mysql2:
         optional: true
@@ -1168,7 +1162,6 @@ packages:
 
   libsql@0.5.13:
     resolution: {integrity: sha512-5Bwoa/CqzgkTwySgqHA5TsaUDRrdLIbdM4egdPcaAnqO3aC+qAgS6BwdzuZwARA5digXwiskogZ8H7Yy4XfdOg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   loupe@3.1.4:
@@ -2121,7 +2114,7 @@ snapshots:
 
   detect-libc@2.0.2: {}
 
-  drizzle-kit@1.0.0-beta.1-f654053:
+  drizzle-kit@1.0.0-beta.1-f92627f:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
@@ -2130,7 +2123,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@1.0.0-beta.1-f654053(patch_hash=2d16276aaca83f4527accdf318385573a33f6c65a277314da3ec99dab205a053)(@libsql/client@0.15.9):
+  drizzle-orm@1.0.0-beta.1-f92627f(patch_hash=2d16276aaca83f4527accdf318385573a33f6c65a277314da3ec99dab205a053)(@libsql/client@0.15.9):
     optionalDependencies:
       '@libsql/client': 0.15.9
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,7 +358,11 @@ export type ResultFieldsToSelection<TResult> =
  * expressions are strongly typed (e.g. `SQL<number>` instead of
  * `SQL<unknown>`).
  */
-export type InsertSelectedFields<TTable extends Table> = {
+export type InsertSelectedFields<
+  TTable extends Table & {
+    $inferInsert: Record<string, unknown>
+  },
+> = {
   [K in keyof TTable['$inferInsert']]: SQLValue<TTable['$inferInsert'][K]>
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ import type {
  */
 export function getOriginalTableName<T extends Table>(
   table: T
-): T['_']['config']['name'] {
+): T['_']['name'] {
   return (table as any)[Symbol.for('drizzle:OriginalName')]
 }
 


### PR DESCRIPTION
@aleclarson Updated to 1.0.0-beta.1-f92627f using the new rqb-typerperf change, removes inferSelect outside of dialectTable & restructures table config access.