### PR TITLE
fix: minimal fix and tests for applying count() to views

### DIFF
--- a/src/extensions/count.ts
+++ b/src/extensions/count.ts
@@ -1,5 +1,7 @@
 import {
+  aliasedTable,
   BuildRelationalQueryResult,
+  getTableAsAliasSQL,
   QueryPromise,
   SQL,
   sql,
@@ -24,11 +26,15 @@ declare module '#dialect/query' {
 RelationalQueryBuilder.prototype.count = function (
   filter?: RelationsFilter<any, any>
 ): CountQueryPromise {
-  const { table, dialect, session } = getContext(this)
+  const originalTable = getContext(this).table
+  const aliased = Object.assign({}, this, {
+    table: aliasedTable(originalTable, 'dp0'),
+  })
+  const { table, dialect, session } = getContext(aliased)
 
   return new CountQueryPromise(
     table,
-    filter && getFilterSQL(this, filter),
+    filter && getFilterSQL(aliased, filter),
     session,
     dialect
   )
@@ -55,7 +61,7 @@ export class CountQueryPromise extends QueryPromise<number> {
   }
 
   getSQL() {
-    const query = sql`select count(*) AS "count" from ${this.table}`
+    const query = sql`select count(*) AS "count" from ${getTableAsAliasSQL(this.table)}`
     if (this.filter) {
       query.append(sql` where ${this.filter}`)
     }

--- a/src/generated/mysql/count.ts
+++ b/src/generated/mysql/count.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import {
+  aliasedTable,
   BuildRelationalQueryResult,
+  getTableAsAliasSQL,
   QueryPromise,
   SQL,
   sql,
@@ -25,11 +27,15 @@ declare module 'drizzle-orm/mysql-core/query-builders/query' {
 RelationalQueryBuilder.prototype.count = function (
   filter?: RelationsFilter<any, any>
 ): CountQueryPromise {
-  const { table, dialect, session } = getContext(this)
+  const originalTable = getContext(this).table
+  const aliased = Object.assign({}, this, {
+    table: aliasedTable(originalTable, 'dp0'),
+  })
+  const { table, dialect, session } = getContext(aliased)
 
   return new CountQueryPromise(
     table,
-    filter && getFilterSQL(this, filter),
+    filter && getFilterSQL(aliased, filter),
     session,
     dialect
   )
@@ -56,7 +62,7 @@ export class CountQueryPromise extends QueryPromise<number> {
   }
 
   getSQL() {
-    const query = sql`select count(*) AS "count" from ${this.table}`
+    const query = sql`select count(*) AS "count" from ${getTableAsAliasSQL(this.table)}`
     if (this.filter) {
       query.append(sql` where ${this.filter}`)
     }

--- a/src/generated/pg/count.ts
+++ b/src/generated/pg/count.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import {
+  aliasedTable,
   BuildRelationalQueryResult,
+  getTableAsAliasSQL,
   QueryPromise,
   SQL,
   sql,
@@ -25,11 +27,15 @@ declare module 'drizzle-orm/pg-core/query-builders/query' {
 RelationalQueryBuilder.prototype.count = function (
   filter?: RelationsFilter<any, any>
 ): CountQueryPromise {
-  const { table, dialect, session } = getContext(this)
+  const originalTable = getContext(this).table
+  const aliased = Object.assign({}, this, {
+    table: aliasedTable(originalTable, 'dp0'),
+  })
+  const { table, dialect, session } = getContext(aliased)
 
   return new CountQueryPromise(
     table,
-    filter && getFilterSQL(this, filter),
+    filter && getFilterSQL(aliased, filter),
     session,
     dialect
   )
@@ -56,7 +62,7 @@ export class CountQueryPromise extends QueryPromise<number> {
   }
 
   getSQL() {
-    const query = sql`select count(*) AS "count" from ${this.table}`
+    const query = sql`select count(*) AS "count" from ${getTableAsAliasSQL(this.table)}`
     if (this.filter) {
       query.append(sql` where ${this.filter}`)
     }

--- a/src/generated/sqlite/count.ts
+++ b/src/generated/sqlite/count.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import {
+  aliasedTable,
   BuildRelationalQueryResult,
+  getTableAsAliasSQL,
   QueryPromise,
   SQL,
   sql,
@@ -26,11 +28,15 @@ declare module 'drizzle-orm/sqlite-core/query-builders/query' {
 RelationalQueryBuilder.prototype.count = function (
   filter?: RelationsFilter<any, any>
 ): CountQueryPromise {
-  const { table, dialect, session } = getContext(this)
+  const originalTable = getContext(this).table
+  const aliased = Object.assign({}, this, {
+    table: aliasedTable(originalTable, 'dp0'),
+  })
+  const { table, dialect, session } = getContext(aliased)
 
   return new CountQueryPromise(
     table,
-    filter && getFilterSQL(this, filter),
+    filter && getFilterSQL(aliased, filter),
     session,
     dialect
   )
@@ -57,7 +63,7 @@ export class CountQueryPromise extends QueryPromise<number> {
   }
 
   getSQL() {
-    const query = sql`select count(*) AS "count" from ${this.table}`
+    const query = sql`select count(*) AS "count" from ${getTableAsAliasSQL(this.table)}`
     if (this.filter) {
       query.append(sql` where ${this.filter}`)
     }

--- a/test/config/localSetup.ts
+++ b/test/config/localSetup.ts
@@ -1,7 +1,10 @@
+import { isTable } from 'drizzle-orm'
 import { db } from './client'
 import * as schema from './schema'
 
 // Truncate all tables.
 await Promise.all(
-  Object.keys(schema).map(table => db.delete(schema[table as never]))
+  Object.values(schema)
+    .filter(relation => isTable(relation))
+    .map(table => db.delete(table))
 )

--- a/test/config/schema.ts
+++ b/test/config/schema.ts
@@ -2,6 +2,7 @@ import {
   integer,
   primaryKey,
   sqliteTable,
+  sqliteView,
   text,
   unique,
 } from 'drizzle-orm/sqlite-core'
@@ -38,3 +39,5 @@ export const userEmail = sqliteTable(
   },
   table => [unique('user_email_unique').on(table.userId, table.email)]
 )
+
+export const userView = sqliteView('user_view').as(qb => qb.select().from(user))

--- a/test/count.test.ts
+++ b/test/count.test.ts
@@ -1,8 +1,9 @@
-import { SQL } from 'drizzle-orm'
+import { gte, SQL } from 'drizzle-orm'
 import { nest } from 'drizzle-plus'
 import 'drizzle-plus/sqlite/count'
 import { getDialect } from 'drizzle-plus/utils'
 import { db } from './config/client'
+import { userView } from './config/schema'
 
 describe('count', () => {
   test('SQL output', () => {
@@ -11,7 +12,7 @@ describe('count', () => {
     expect(query.toSQL()).toMatchInlineSnapshot(`
       {
         "params": [],
-        "sql": "select count(*) AS "count" from "user"",
+        "sql": "select count(*) AS "count" from "user" as "dp0"",
       }
     `)
 
@@ -24,7 +25,7 @@ describe('count', () => {
         "params": [
           100,
         ],
-        "sql": "select count(*) AS "count" from "user" where "user"."id" > ?",
+        "sql": "select count(*) AS "count" from "user" as "dp0" where "dp0"."id" > ?",
       }
     `)
   })
@@ -38,7 +39,7 @@ describe('count', () => {
     expect(getDialect(query).sqlToQuery(nestedQuery)).toMatchInlineSnapshot(`
       {
         "params": [],
-        "sql": "(select count(*) AS "count" from "user")",
+        "sql": "(select count(*) AS "count" from "user" as "dp0")",
       }
     `)
 
@@ -53,8 +54,23 @@ describe('count', () => {
     expect(query.toSQL()).toMatchInlineSnapshot(`
       {
         "params": [],
-        "sql": "select count(*) AS "count" from "user" where exists (select * from "user_email" as "f0" where "user"."id" = "f0"."userId" limit 1)",
+        "sql": "select count(*) AS "count" from "user" as "dp0" where exists (select * from "user_email" as "f0" where "dp0"."id" = "f0"."userId" limit 1)",
       }
     `)
+  })
+
+  test('on view', async () => {
+    const expectedCount = await db.$count(userView, gte(userView.age, 30))
+    const query = db.query.userView.count({ age: { gte: 30 } })
+
+    expect(query.toSQL()).toMatchInlineSnapshot(`
+      {
+        "params": [
+          30,
+        ],
+        "sql": "select count(*) AS "count" from "user_view" as "dp0" where "dp0"."age" >= ?",
+      }
+    `)
+    expect(await query).toBe(expectedCount)
   })
 })

--- a/test/findManyAndCount.test.ts
+++ b/test/findManyAndCount.test.ts
@@ -20,7 +20,7 @@ describe('findManyAndCount', () => {
       {
         "count": {
           "params": [],
-          "sql": "select count(*) AS "count" from "user"",
+          "sql": "select count(*) AS "count" from "user" as "dp0"",
         },
         "findMany": {
           "params": [],
@@ -41,7 +41,7 @@ describe('findManyAndCount', () => {
           "params": [
             100,
           ],
-          "sql": "select count(*) AS "count" from "user" where "user"."id" > ?",
+          "sql": "select count(*) AS "count" from "user" as "dp0" where "dp0"."id" > ?",
         },
         "findMany": {
           "params": [


### PR DESCRIPTION
In count(), uses getTableAsAliasSQL() on the table/view to alias the table/view as "dp0"

Fixes #19 